### PR TITLE
优化nginx和php-fpm配置文件，修复服务器重启导致的错误

### DIFF
--- a/Nginx/nginx
+++ b/Nginx/nginx
@@ -32,6 +32,7 @@ start() {
     [ -x $nginx ] || exit 5
     [ -f $NGINX_CONF_FILE ] || exit 6
     echo -n $"Starting $prog: "
+    mkdir -p /var/run/nginx/
     daemon $nginx -c $NGINX_CONF_FILE
     retval=$?
     echo

--- a/PHP/php-fpm
+++ b/PHP/php-fpm
@@ -54,6 +54,8 @@ case "$1" in
 	start)
 		echo -n "Starting php-fpm "
 
+		mkdir -p /var/run/php-fpm/
+
 		$php_fpm_BIN --daemonize $php_opts
 
 		if [ "$?" != 0 ] ; then


### PR DESCRIPTION
修复服务器重启没有创建/var/run/nginx和/var/run/php-fpm文件夹导致不能启动服务的错误
